### PR TITLE
BCR-17513 get package name fix

### DIFF
--- a/lib/spm_version_updates/local.rb
+++ b/lib/spm_version_updates/local.rb
@@ -33,7 +33,8 @@ def get_dependencies(manifest)
 end
 
 def package_name(content)
-  content.scan(/Package\(\s*name:\s*"([^"]+)"/).first.first
+  match = content.scan(/Package\(\s*name:\s*"([^"]+)"/).first
+  match ? match.first : "UNKNOWN PACKAGE NAME"
 end
 
 def requirement_kinds


### PR DESCRIPTION
# Что сделано
- при подключении к репозиторию бауцентра обнаружилась проблема: не всегда находится имя пакета, поэтому была добавлена проверка: если не нашло имя, используй "UNKNOWN PACKAGE NAME"